### PR TITLE
Add config parameter to disable collapsible cursors (#37967)

### DIFF
--- a/src/vs/editor/common/config/commonEditorConfig.ts
+++ b/src/vs/editor/common/config/commonEditorConfig.ts
@@ -352,6 +352,11 @@ const editorConfiguration: IConfigurationNode = {
 				]
 			}, "The modifier to be used to add multiple cursors with the mouse. `ctrlCmd` maps to `Control` on Windows and Linux and to `Command` on OSX. The Go To Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier.")
 		},
+		'editor.multiCursorCollapsible': {
+			'type': 'boolean',
+			'default': EDITOR_DEFAULTS.multiCursorCollapsible,
+			'description': nls.localize('multiCursorCollapsible', "Enable cursors to collapse when overlapping.")
+		},
 		'editor.quickSuggestions': {
 			'anyOf': [
 				{

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -368,6 +368,11 @@ export interface IEditorOptions {
 	 */
 	multiCursorModifier?: 'ctrlCmd' | 'alt';
 	/**
+	 * Enable cursors to collapse when overlapping.
+	 * Defaults to true
+	 */
+	multiCursorCollapsible?: boolean;
+	/**
 	 * Configure the editor's accessibility support.
 	 * Defaults to 'auto'. It is best to leave this to 'auto'.
 	 */
@@ -840,6 +845,7 @@ export interface IValidatedEditorOptions {
 	readonly emptySelectionClipboard: boolean;
 	readonly useTabStops: boolean;
 	readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
+	readonly multiCursorCollapsible: boolean;
 	readonly accessibilitySupport: 'auto' | 'off' | 'on';
 
 	readonly viewInfo: InternalEditorViewOptions;
@@ -862,6 +868,7 @@ export class InternalEditorOptions {
 	 */
 	readonly accessibilitySupport: platform.AccessibilitySupport;
 	readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
+	readonly multiCursorCollapsible: boolean;
 
 	// ---- cursor options
 	readonly wordSeparators: string;
@@ -890,6 +897,7 @@ export class InternalEditorOptions {
 		readOnly: boolean;
 		accessibilitySupport: platform.AccessibilitySupport;
 		multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
+		multiCursorCollapsible: boolean;
 		wordSeparators: string;
 		autoClosingBrackets: boolean;
 		autoIndent: boolean;
@@ -910,6 +918,7 @@ export class InternalEditorOptions {
 		this.readOnly = source.readOnly;
 		this.accessibilitySupport = source.accessibilitySupport;
 		this.multiCursorModifier = source.multiCursorModifier;
+		this.multiCursorCollapsible = source.multiCursorCollapsible;
 		this.wordSeparators = source.wordSeparators;
 		this.autoClosingBrackets = source.autoClosingBrackets;
 		this.autoIndent = source.autoIndent;
@@ -936,6 +945,7 @@ export class InternalEditorOptions {
 			&& this.readOnly === other.readOnly
 			&& this.accessibilitySupport === other.accessibilitySupport
 			&& this.multiCursorModifier === other.multiCursorModifier
+			&& this.multiCursorCollapsible === other.multiCursorCollapsible
 			&& this.wordSeparators === other.wordSeparators
 			&& this.autoClosingBrackets === other.autoClosingBrackets
 			&& this.autoIndent === other.autoIndent
@@ -963,6 +973,7 @@ export class InternalEditorOptions {
 			readOnly: (this.readOnly !== newOpts.readOnly),
 			accessibilitySupport: (this.accessibilitySupport !== newOpts.accessibilitySupport),
 			multiCursorModifier: (this.multiCursorModifier !== newOpts.multiCursorModifier),
+			multiCursorCollapsible: (this.multiCursorCollapsible !== newOpts.multiCursorCollapsible),
 			wordSeparators: (this.wordSeparators !== newOpts.wordSeparators),
 			autoClosingBrackets: (this.autoClosingBrackets !== newOpts.autoClosingBrackets),
 			autoIndent: (this.autoIndent !== newOpts.autoIndent),
@@ -1307,6 +1318,7 @@ export interface IConfigurationChangedEvent {
 	readonly readOnly: boolean;
 	readonly accessibilitySupport: boolean;
 	readonly multiCursorModifier: boolean;
+	readonly multiCursorCollapsible: boolean;
 	readonly wordSeparators: boolean;
 	readonly autoClosingBrackets: boolean;
 	readonly autoIndent: boolean;
@@ -1492,6 +1504,7 @@ export class EditorOptionsValidator {
 			emptySelectionClipboard: _boolean(opts.emptySelectionClipboard, defaults.emptySelectionClipboard),
 			useTabStops: _boolean(opts.useTabStops, defaults.useTabStops),
 			multiCursorModifier: multiCursorModifier,
+			multiCursorCollapsible: _boolean(opts.multiCursorCollapsible, defaults.multiCursorCollapsible),
 			accessibilitySupport: _stringSet<'auto' | 'on' | 'off'>(opts.accessibilitySupport, defaults.accessibilitySupport, ['auto', 'on', 'off']),
 			viewInfo: viewInfo,
 			contribInfo: contribInfo,
@@ -1721,6 +1734,7 @@ export class InternalEditorOptionsFactory {
 			emptySelectionClipboard: opts.emptySelectionClipboard,
 			useTabStops: opts.useTabStops,
 			multiCursorModifier: opts.multiCursorModifier,
+			multiCursorCollapsible: opts.multiCursorCollapsible,
 			accessibilitySupport: opts.accessibilitySupport,
 
 			viewInfo: {
@@ -1924,6 +1938,7 @@ export class InternalEditorOptionsFactory {
 			readOnly: opts.readOnly,
 			accessibilitySupport: accessibilitySupport,
 			multiCursorModifier: opts.multiCursorModifier,
+			multiCursorCollapsible: opts.multiCursorCollapsible,
 			wordSeparators: opts.wordSeparators,
 			autoClosingBrackets: opts.autoClosingBrackets,
 			autoIndent: opts.autoIndent,
@@ -2145,6 +2160,7 @@ export const EDITOR_DEFAULTS: IValidatedEditorOptions = {
 	emptySelectionClipboard: true,
 	useTabStops: true,
 	multiCursorModifier: 'altKey',
+	multiCursorCollapsible: true,
 	accessibilitySupport: 'auto',
 
 	viewInfo: {

--- a/src/vs/editor/common/controller/cursorCollection.ts
+++ b/src/vs/editor/common/controller/cursorCollection.ts
@@ -193,6 +193,10 @@ export class CursorCollection {
 			const currentViewSelection = current.viewSelection;
 			const nextViewSelection = next.viewSelection;
 
+			if (!this.context.config.multiCursorCollapsible) {
+				continue;
+			}
+
 			let shouldMergeCursors: boolean;
 			if (nextViewSelection.isEmpty() || currentViewSelection.isEmpty()) {
 				// Merge touching cursors if one of them is collapsed

--- a/src/vs/editor/common/controller/cursorCommon.ts
+++ b/src/vs/editor/common/controller/cursorCommon.ts
@@ -77,6 +77,7 @@ export class CursorConfiguration {
 	public readonly useTabStops: boolean;
 	public readonly wordSeparators: string;
 	public readonly emptySelectionClipboard: boolean;
+	public readonly multiCursorCollapsible: boolean;
 	public readonly autoClosingBrackets: boolean;
 	public readonly autoIndent: boolean;
 	public readonly autoClosingPairsOpen: CharacterMap;
@@ -113,6 +114,7 @@ export class CursorConfiguration {
 		this.useTabStops = c.useTabStops;
 		this.wordSeparators = c.wordSeparators;
 		this.emptySelectionClipboard = c.emptySelectionClipboard;
+		this.multiCursorCollapsible = c.multiCursorCollapsible;
 		this.autoClosingBrackets = c.autoClosingBrackets;
 		this.autoIndent = c.autoIndent;
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2699,6 +2699,11 @@ declare module monaco.editor {
 		 */
 		multiCursorModifier?: 'ctrlCmd' | 'alt';
 		/**
+		 * Enable cursors to collapse when overlapping.
+		 * Defaults to true
+		 */
+		multiCursorCollapsible?: boolean;
+		/**
 		 * Configure the editor's accessibility support.
 		 * Defaults to 'auto'. It is best to leave this to 'auto'.
 		 */
@@ -3099,6 +3104,7 @@ declare module monaco.editor {
 		readonly lineHeight: number;
 		readonly readOnly: boolean;
 		readonly multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey';
+		readonly multiCursorCollapsible: boolean;
 		readonly wordSeparators: string;
 		readonly autoClosingBrackets: boolean;
 		readonly autoIndent: boolean;
@@ -3232,6 +3238,7 @@ declare module monaco.editor {
 		readonly readOnly: boolean;
 		readonly accessibilitySupport: boolean;
 		readonly multiCursorModifier: boolean;
+		readonly multiCursorCollapsible: boolean;
 		readonly wordSeparators: boolean;
 		readonly autoClosingBrackets: boolean;
 		readonly autoIndent: boolean;


### PR DESCRIPTION
Fix to issue: https://github.com/Microsoft/vscode/issues/37967

Initial Behaviour:
![initial_behaviour](https://user-images.githubusercontent.com/6786671/32707280-b3bcaf3e-c7f0-11e7-9dde-70ded587f32f.gif)

Disable collapsible cursors in user settings:
```
{
    "editor.multiCursorCollapsible": false
}
```

New Behaviour:
![new_behaviour](https://user-images.githubusercontent.com/6786671/32707283-b6047c54-c7f0-11e7-8d80-38dc7b1add1f.gif)



